### PR TITLE
add void type for returning nothing

### DIFF
--- a/annotation/typed.py
+++ b/annotation/typed.py
@@ -26,13 +26,14 @@ This module provides a set of tools for type checking and annotations:
 
 __author__ = ('Manuel Cerón <ceronman@gmail.com>')
 __all__ = ['AnyType', 'Interface', 'only', 'optional', 'options', 'predicate',
-           'typechecked', 'typedef', 'union']
+           'typechecked', 'typedef', 'union', 'void']
 
 import functools
 import inspect
 
 EMPTY_ANNOTATION = inspect.Signature.empty
 
+void = type(None) # An alias for `type(None)` e.g. for returning nothing.
 
 class UnionMeta(type):
     """Metaclass for union types.


### PR DESCRIPTION
It would be nice to have `void`as an alias for `type(None)`, e.g for returning Nothing, so that you can write something like:

``` python
@typechecked
def function(a: int) -> void:
    pass
```

`void`is a very common keyword to indicate that a function returns no value, so for most users it is clear what `void`indicates. It is faster to write and in my opinion better to read then `type(None)`.
